### PR TITLE
Update Raster_Eigen_TreeLocations.R

### DIFF
--- a/R/Raster_Eigen_TreeLocations.R
+++ b/R/Raster_Eigen_TreeLocations.R
@@ -168,10 +168,10 @@ get_raster_eigen_treelocs <- function(las = las, res = 0.05, pt_spacing = 0.0254
                                         fun = max)[,2], 2)
 
   merged <- merged[merged$SDvert < SDvert, ]
-  merged <- merged[merged$diffHGT > grid_slice_max*0.5, ]
+  merged <- merged[merged$diffHGT > (grid_slice_max-grid_slice_min)*0.5, ]
   # ## low and high within the slice
   merged <- merged[merged$lowHGT < (grid_slice_min*1.25), ]
-  merged <- merged[merged$medHGT <= grid_slice_max*0.75, ]
+  #merged <- merged[merged$medHGT <= grid_slice_max*0.75, ]
   merged <- merged[merged$maxHGT >= grid_slice_max, ]
 
   message("Obtaining polygon attributes...(10/14)\n")


### PR DESCRIPTION
•	Right now you’re checking to see if returns from putative tree cover most of the slice.
•	With  a grid slice 0.66 to 2 (difference should be =  1.34) which is > max_slice (2) * 0.5 = 1
•	But if you use a slice from 1 to 2 (which I did because we have lots of low vegetation this will fail
•	If grid slice goes from 1 to 2, expected difference is 1 m (in reality slightly less because returns arent’ perfectly at the max and min (so 0.95 or so)
•	Then there are NO trees that satisfy max_slice * 0.5 (2.0 * 0.5 = 1) because all are less than 1
•	So *no* trees stay included.
•	The adjusted code looks at the difference and says the slice should take up 60% of the slice… but maybe you want it to be higher/lower.

